### PR TITLE
Add a special apply tag + attribute substitution

### DIFF
--- a/Larceny.hs
+++ b/Larceny.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 import           Data.Map           (Map)
 import qualified Data.Map           as M
-import           Data.Maybe         (fromJust, isJust)
+import           Data.Maybe         (catMaybes, fromJust, isJust)
 import           Data.Monoid        ((<>))
 import           Data.Set           (Set)
 import qualified Data.Set           as S
@@ -83,37 +83,54 @@ plainNodes = ["body", "p", "h1", "img"]
 parse :: Text -> Template
 parse t = let Right (X.HtmlDocument _ _ nodes) = X.parseHTML "" (T.encodeUtf8 t)
           in mk nodes
-  where mk :: [X.Node] -> Template
-        mk nodes = let unbound = findUnbound nodes
-          in Template $ \m l -> need m (map Hole unbound) (T.concat $ process m l unbound nodes)
-        process :: Substitution -> Library -> [Text] -> [X.Node] -> [Text]
-        process m l unbound [] = []
-        process m l unbound (n:ns) =
-          case n of
-            X.Element tn atr kids ->
-              if tn `elem` plainNodes
-              then ["<" <> tn <> attrsToText atr <> ">"] ++ process m l unbound kids ++ ["</" <> tn <> ">"]
-              else
-                if tn == "apply" && isJust (lookup "name" atr)
-                   -- then lookup and run the template given, along with a new substitution for content
-                then
-                  let tplToApply = l M.! (fromJust (lookup "name" atr))
-                      contentSub = sub [("content", (\t l -> runTemplate (mk kids) m l))] in
-                  [ runTemplate tplToApply (contentSub `M.union` m) l ]
-                else [(m M.! (Hole tn)) (add m (mk kids)) l]
-            X.TextNode t ->  [t]
-            X.Comment c -> ["<!--" <> c <> "-->"]
-          ++ process m l unbound ns
-        attrsToText attrs = T.concat $ map (\(x,y) -> " " <> x <> "=\"" <> y <> "\"") attrs
-        findUnbound [] = []
-        findUnbound (n:ns) =
-          case n of
-            X.Element tn _ kids ->
-              if X.elementTag n `elem` plainNodes || X.elementTag n `elem` specialNodes
-                then findUnbound (X.elementChildren n)
-                else [X.elementTag n]
-            _ -> []
-          ++ findUnbound ns
+
+mk :: [X.Node] -> Template
+mk nodes = let unbound = findUnbound nodes
+           in Template $ \m l -> need m (map Hole unbound) (T.concat $ process m l unbound nodes)
+
+process :: Substitution -> Library -> [Text] -> [X.Node] -> [Text]
+process m l unbound [] = []
+process m l unbound (n:ns) =
+  case n of
+   X.Element tn atr kids ->
+     if tn `elem` plainNodes
+     then ["<" <> tn <> attrsToText atr <> ">"] ++ process m l unbound kids ++ ["</" <> tn <> ">"]
+     else
+       if tn == "apply" && isJust (lookup "name" atr)
+       then
+         let tplToApply = l M.! (fromJust (lookup "name" atr))
+             contentSub = sub [("content", (\t l -> runTemplate (mk kids) m l))] in
+         [ runTemplate tplToApply (contentSub `M.union` m) l ]
+       else [(m M.! (Hole tn)) (add m (mk kids)) l]
+   X.TextNode t ->  [t]
+   X.Comment c -> ["<!--" <> c <> "-->"]
+   ++ process m l unbound ns
+  where attrsToText attrs = T.concat $ map attrToText attrs
+        attrToText :: (Text, Text) -> Text
+        attrToText atr =
+          case mUnboundAttr atr of
+            Just hole -> " " <> fst atr <> "=\"" <> ((m M.! (Hole hole)) (mk []) l)  <> "\""
+            Nothing   -> " " <> fst atr <> "=\"" <> snd atr <> "\""
+
+findUnbound :: [X.Node] -> [Text]
+findUnbound [] = []
+findUnbound (n:ns) =
+  case n of
+   X.Element tn atr kids ->
+     if X.elementTag n `elem` plainNodes || X.elementTag n `elem` specialNodes
+     then findUnboundAttrs atr ++ findUnbound (X.elementChildren n)
+     else X.elementTag n : findUnboundAttrs atr
+   _ -> []
+   ++ findUnbound ns
+   where
+
+findUnboundAttrs :: [(Text, Text)] -> [Text]
+findUnboundAttrs atrs = catMaybes $ map mUnboundAttr atrs
+
+mUnboundAttr :: (Text, Text) -> Maybe Text
+mUnboundAttr (_, value) = do
+  endVal <- T.stripPrefix "${" value
+  T.stripSuffix "}" endVal
 
 page' = "<body>\
          \ <site-title/>\
@@ -148,8 +165,7 @@ spec = hspec $ do
       (page', subst, mempty) `shouldRender` page''
     it "should allow attributes" $ do
       ("<p id=\"hello\">hello</p>", mempty, mempty) `shouldRender` "<p id=\"hello\">hello</p>"
-      -- below is not quite right?!
-      ("<img src=\"hello\" alt=\"hello\" />", mempty, mempty) `shouldRender` "<img src=\"hello\" alt=\"hello\"></img>"
+      ("<img src=\"hello\" alt=\"hello\" />", mempty, mempty) `shouldRender` "<img src=\"hello\" alt=\"hello\" />"
   describe "add" $ do
     it "should allow overriden tags" $ do
       ("<name /><person><name /></person>", subst', mempty) `shouldRender` "My siteDaniel"
@@ -162,3 +178,12 @@ spec = hspec $ do
       ("<apply name=\"person\">Libby</apply>", mempty, M.fromList [("person", parse "<content />")]) `shouldRender` "Libby"
     it "should allow even more compicated templates to be included in other templates" $ do
       ("<apply name=\"person\"><p>Libby</p></apply>", sub [("food", text "pizza")], M.fromList [("person", parse "<food /><content />")]) `shouldRender` "pizza<p>Libby</p>"
+  describe "attributes" $ do
+    it "should apply substitutions to attributes as well" $ do
+      ("<p id=\"${name}\"><name /></p>", sub [("name", text "McGonagall")], mempty) `shouldRender` "<p id=\"McGonagall\">McGonagall</p>"
+  describe "findUnbound" $ do
+    it "should find stuff matching the pattern ${blah}" $ do
+      findUnbound [X.Element "p" [("blah", "${blah}")] []] `shouldBe` ["blah"]
+  describe "findUnboundAttrs" $ do
+    it "should find stuff matching the pattern ${blah}" $ do
+      findUnboundAttrs [("blah", "${blah}")] `shouldBe` ["blah"]


### PR DESCRIPTION
Here's what I came up with for apply!

I added some type annotations too because I was a little confused by all the inline functions.

This looks at whether the tag is "apply" and it has an attribute "name". Then it looks up the template with that name and runs it along with a new substitution for "content". The fill for content is \<apply\>'s  children.