### PR TITLE
Experiments

### DIFF
--- a/src/Larceny.hs
+++ b/src/Larceny.hs
@@ -10,11 +10,12 @@ import qualified Data.Set           as S
 import           Data.Text          (Text)
 import qualified Data.Text          as T
 import qualified Data.Text.Encoding as T
+import           Debug.Trace        (trace)
 import qualified Text.XmlHtml       as X
 
 newtype Hole = Hole Text deriving (Eq, Show, Ord)
 type Fill = Template -> Library -> Text
-type Substitution = Map Hole Fill
+newtype Substitution = Substitution { findFill :: Map Hole (Substitution -> Fill) }
 newtype Template = Template { runTemplate :: Substitution -> Library -> Text }
 type Library = Map Text Template
 
@@ -27,30 +28,41 @@ need m keys rest =
         then rest
         else error $ "Missing keys: " <> show d
 
+union :: Substitution -> Substitution -> Substitution
+union (Substitution s1) (Substitution s2) = Substitution (s1 `M.union` s2)
+
+sempty :: Substitution
+sempty = Substitution mempty
+
 add :: Substitution -> Template -> Template
-add mouter tpl = Template (\minner l -> runTemplate tpl (minner `M.union` mouter) l)
+add mouter tpl = Template (\minner l -> runTemplate tpl (minner `union` mouter) l)
 
--- works to create both Templates and Fills?
-text :: Text -> Fill
-text t = \_ _ -> t
+text :: Text -> Substitution -> Fill
+text t = \_ _ _ -> t
 
-mapSub :: (a -> Substitution) -> [a] -> Fill
-mapSub f xs = \tpl lib ->
+mapSub :: (a -> Substitution) -> [a] -> (Substitution -> Fill)
+mapSub f xs = \_ tpl lib ->
   T.concat $
   map (\n ->
         runTemplate tpl (f n) lib) xs
 
+funkyFill :: Text -> (Text -> Text) -> (Substitution -> Fill)
+funkyFill argName f = trace (show $ argName) $
+  (\m _ l ->
+    let argText = fillIn argName m m (mk []) l in
+    f argText)
+
 funkyTpl :: Text -> (Text -> Text) -> Template
 funkyTpl argName f = Template
-  (\m l ->
-    let argText = (m M.! Hole argName) (mk []) l in
-    need m [Hole argName] $  f argText)
+  (\m@(Substitution s) l ->
+    let argText = fillIn argName m m (mk []) l in
+    need s [Hole argName] $  f argText)
 
-sub :: [(Text, Fill)] -> Substitution
-sub = M.fromList . map (\(x,y) -> (Hole x, y))
+sub :: [(Text, Substitution -> Fill)] -> Substitution
+sub xs = Substitution $ M.fromList (map (\(x,y) -> (Hole x, y)) xs)
 
-fill :: Substitution -> Fill
-fill s = \(Template tpl) -> tpl s
+fill :: Substitution -> (Substitution -> Fill)
+fill s = \s' (Template tpl) -> tpl (s `union` s')
 
 specialNodes :: [Text]
 specialNodes = ["apply"]
@@ -64,7 +76,9 @@ parse t = let Right (X.HtmlDocument _ _ nodes) = X.parseHTML "" (T.encodeUtf8 t)
 
 mk :: [X.Node] -> Template
 mk nodes = let unbound = findUnbound nodes
-           in Template $ \m l -> need m (map Hole unbound) (T.concat $ process m l unbound nodes)
+           in Template $ \m@(Substitution s) l ->
+                          need s (map Hole unbound)
+                                 (T.concat $ process m l unbound nodes)
 
 process :: Substitution -> Library -> [Text] -> [X.Node] -> [Text]
 process _ _ _ [] = []
@@ -94,10 +108,10 @@ processFancy :: Substitution -> Library ->
 processFancy m l tn atr kids =
   -- add attrs as substitutions
   let attrSubs = sub $ map (\(k,v) -> (k, text v)) atr in
-  [ fillIn tn m (add (attrSubs `M.union` m) (mk kids)) l]
+  [ fillIn tn (attrSubs `union` m) (attrSubs `union` m) (add (attrSubs `union` m) (mk kids)) l]
 
-fillIn :: Text -> Substitution -> Fill
-fillIn tn m = m M.! Hole tn
+fillIn :: Text -> Substitution -> Substitution -> Fill
+fillIn tn (Substitution m) = m M.! Hole tn
 
 -- Look up the template that's supposed to be applied in the library,
 -- add all the attributes as text substitutions, create a substitution
@@ -113,8 +127,8 @@ processApply m l atr kids =
       tplToApply = l M.! tplName
       attrSubs = sub $ map (\(k,v) -> (k, text v)) atr
       contentSub = sub [("content",
-                         \_ l' -> runTemplate (mk kids) m l')] in
-  [ runTemplate tplToApply (contentSub `M.union` (attrSubs `M.union` m)) l ]
+                         \_ _ l' -> runTemplate (mk kids) m l')] in
+  [ runTemplate tplToApply (contentSub `union` (attrSubs `union` m)) l ]
 
 attrsToText :: Substitution -> Library -> [(Text, Text)] -> Text
 attrsToText m l attrs= T.concat $ map attrToText attrs
@@ -122,7 +136,7 @@ attrsToText m l attrs= T.concat $ map attrToText attrs
     attrToText atr =
       case mUnboundAttr atr of
        Just hole -> " " <> fst atr <> "=\"" <>
-                    fillIn hole m (mk []) l  <> "\""
+                    fillIn hole m m (mk []) l  <> "\""
        Nothing   -> " " <> fst atr <> "=\"" <> snd atr <> "\""
 
 findUnbound :: [X.Node] -> [Text]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -81,7 +81,7 @@ spec = hspec $ do
     it "should parse HTML into a Template" $ do
       (page', subst, mempty) `shouldRender` page''
     it "should allow attributes" $ do
-      ("<p id=\"hello\">hello</p>", sempty, mempty) `shouldRender` "<p id=\"hello\">hello</p>"
+      ("<p id=\"hello\">hello</p>", mempty, mempty) `shouldRender` "<p id=\"hello\">hello</p>"
 
   describe "add" $ do
     it "should allow overriden tags" $ do
@@ -90,7 +90,7 @@ spec = hspec $ do
   describe "apply" $ do
     it "should allow templates to be included in other templates" $ do
       ("<apply name=\"hello\" />",
-       sempty,
+       mempty,
        M.fromList [("hello", parse "hello")]) `shouldRender` "hello"
     it "should allow templates with unfilled holes to be included in other templates" $ do
       ("<apply name=\"skater\" />",
@@ -98,7 +98,7 @@ spec = hspec $ do
        M.fromList [("skater", parse "<alias />")]) `shouldRender` "Fifi Nomenom"
     it "should allow templates to be included in other templates" $ do
       ("<apply name=\"person\">Libby</apply>",
-       sempty,
+       mempty,
        M.fromList [("person", parse "<content />")]) `shouldRender` "Libby"
     it "should allow compicated templates to be included in other templates" $ do
       ("<apply name=\"person\"><p>Libby</p></apply>",
@@ -118,23 +118,13 @@ spec = hspec $ do
 
     it "should allow you to use attributes as substitutions" $ do
       ("<skater alias=\"Bonnie Thunders\"><alias /></skater>",
-       sub [("skater", fill sempty)],
+       sub [("skater", fill mempty)],
        mempty) `shouldRender` "Bonnie Thunders"
 
-  describe "funky fills" $ do
-    it "should allow you to write functions for fills" $ do
-      ("<description length=\"10\" />",
-       sub [("description", funkyFill "length"
-                              (\n -> T.take ((read $T.unpack n) :: Int)
-                                      "A really long description"
-                                      <> "..."))],
-       mempty)
-        `shouldRender` "A really l..."
-
   describe "funky templates" $ do
-    it "should allow you to write functions for templates" $ do
+    it "should allow you to write functions for fills" $ do
       ("<apply name=\"description\" length=\"10\" />",
-       sempty,
+       mempty,
        M.fromList [("description", funkyTpl "length"
                               (\n -> T.take ((read $T.unpack n) :: Int)
                                       "A really long description"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -81,7 +81,7 @@ spec = hspec $ do
     it "should parse HTML into a Template" $ do
       (page', subst, mempty) `shouldRender` page''
     it "should allow attributes" $ do
-      ("<p id=\"hello\">hello</p>", mempty, mempty) `shouldRender` "<p id=\"hello\">hello</p>"
+      ("<p id=\"hello\">hello</p>", sempty, mempty) `shouldRender` "<p id=\"hello\">hello</p>"
 
   describe "add" $ do
     it "should allow overriden tags" $ do
@@ -90,7 +90,7 @@ spec = hspec $ do
   describe "apply" $ do
     it "should allow templates to be included in other templates" $ do
       ("<apply name=\"hello\" />",
-       mempty,
+       sempty,
        M.fromList [("hello", parse "hello")]) `shouldRender` "hello"
     it "should allow templates with unfilled holes to be included in other templates" $ do
       ("<apply name=\"skater\" />",
@@ -98,7 +98,7 @@ spec = hspec $ do
        M.fromList [("skater", parse "<alias />")]) `shouldRender` "Fifi Nomenom"
     it "should allow templates to be included in other templates" $ do
       ("<apply name=\"person\">Libby</apply>",
-       mempty,
+       sempty,
        M.fromList [("person", parse "<content />")]) `shouldRender` "Libby"
     it "should allow compicated templates to be included in other templates" $ do
       ("<apply name=\"person\"><p>Libby</p></apply>",
@@ -118,13 +118,23 @@ spec = hspec $ do
 
     it "should allow you to use attributes as substitutions" $ do
       ("<skater alias=\"Bonnie Thunders\"><alias /></skater>",
-       sub [("skater", fill mempty)],
+       sub [("skater", fill sempty)],
        mempty) `shouldRender` "Bonnie Thunders"
 
-  describe "funky templates" $ do
+  describe "funky fills" $ do
     it "should allow you to write functions for fills" $ do
+      ("<description length=\"10\" />",
+       sub [("description", funkyFill "length"
+                              (\n -> T.take ((read $T.unpack n) :: Int)
+                                      "A really long description"
+                                      <> "..."))],
+       mempty)
+        `shouldRender` "A really l..."
+
+  describe "funky templates" $ do
+    it "should allow you to write functions for templates" $ do
       ("<apply name=\"description\" length=\"10\" />",
-       mempty,
+       sempty,
        M.fromList [("description", funkyTpl "length"
                               (\n -> T.take ((read $T.unpack n) :: Int)
                                       "A really long description"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,20 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-import           Data.Map           (Map)
-import qualified Data.Map           as M
-import           Data.Maybe         (catMaybes, fromJust, isJust)
-import           Data.Monoid        ((<>))
-import           Data.Set           (Set)
-import qualified Data.Set           as S
-import           Data.Text          (Text)
-import qualified Data.Text          as T
-import qualified Data.Text.Encoding as T
+import qualified Data.Map     as M
+import           Data.Text    (Text)
+import qualified Data.Text    as T
 import           Larceny
 import           Test.Hspec
-import qualified Text.XmlHtml       as X
+import qualified Text.XmlHtml as X
 
+main :: IO ()
 main = spec
 
+page' :: Text
 page' = "<body>\
          \ <site-title/>\
               \ <people>\
@@ -23,6 +19,7 @@ page' = "<body>\
               \ </people>\
               \</body>"
 
+page'' :: Text
 page'' = "<body>\
               \ My site\
               \   <p>Daniel</p>\
@@ -47,18 +44,19 @@ subst = (M.fromList [ (Hole "site-title", text "My site")
                                             l)
                        ["Daniel", "Matt", "Cassie", "Libby"])])
 
+subst' :: Substitution
 subst' = sub [ ("site-title", text "My site")
              , ("name", text "My site")
              , ("person", fill $ sub [("name", text "Daniel")])
-             , ("people", mapHoles (\n -> sub $ [("name", text n)]) ["Daniel", "Matt", "Cassie", "Libby"]) ]
-
-render' = runTemplate (parse page') subst
+             , ("people", mapSub (\n -> sub $ [("name", text n)])
+                          ["Daniel", "Matt", "Cassie", "Libby"]) ]
 
 shouldRender :: (Text, Substitution, Library) -> Text -> Expectation
-shouldRender (template, subst, lib) output =
-  T.replace " " "" (runTemplate (parse template) subst lib) `shouldBe`
+shouldRender (t, s, l) output =
+  T.replace " " "" (runTemplate (parse t) s l) `shouldBe`
   T.replace " " "" output
 
+spec :: IO ()
 spec = hspec $ do
   describe "parse" $ do
     it "should parse HTML into a Template" $ do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -116,7 +116,6 @@ spec = hspec $ do
        sub [("name", text "McGonagall")],
        mempty) `shouldRender` "<p id=\"McGonagall\">McGonagall</p>"
 
-  -- WAT? I'm really surpised this works
     it "should allow you to use attributes as substitutions" $ do
       ("<skater alias=\"Bonnie Thunders\"><alias /></skater>",
        sub [("skater", fill mempty)],


### PR DESCRIPTION
(Not a real pull request)

Trying to figure out how to do `<description length="100" />`. Still not there yet, but wanted to share my experiments.

```(haskell)
    it "should allow you to use attributes as substitutions" $ do
      ("<skater alias=\"Bonnie Thunders\"><alias /></skater>",
       sub [("skater", fill mempty)],
       mempty) `shouldRender` "Bonnie Thunders"
```
was pretty easy! Which is kinda like `bind`? But this is making *every* fill into `bind`, which is probably not what we want. :)

Then I started trying for functions in fills and got very stuck. I had this idea of putting the arguments to the function in substitutions, like in the `alias` example above. But fills don't know about substitutions. Templates do, so I was able to make this:

```(haskell)
    it "should allow you to write functions for templates" $ do
      ("<apply name=\"description\" length=\"10\" />",
       mempty,
       M.fromList [("description", funkyTpl "length"
                              (\n -> T.take ((read $T.unpack n) :: Int)
                                      "A really long description"
                                      <> "..."))])
        `shouldRender` "A really l..."
```

But I don't know how useful that is. Right now the functions can only have one argument, too. I imagine there's ways around that (perhaps with ~continuations~?), but I think I'm just going down the wrong rabbit hole here.