### PR TITLE
Create exception types instead of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,21 @@ And "substitutions" that look like this:
 ```
 teamPageSubs :: Substitutions ()
 teamPageSubs =
-  subs [ ("name", text "Gotham Girls")
+  subs [ ("name", textFill "Gotham Girls")
        , ("skaters", mapSubs
                      (\(i,n,p,b) ->
-                       subs [ ("id", text i)
-                            , ("name", text n)
-                            , ("position", text p)
-                            , ("longBio", text b)])
+                       subs [ ("id", textFill i)
+                            , ("name", textFill n)
+                            , ("position", textFill p)
+                            , ("longBio", textFill b)])
                     [ ("1", "Bonnie Thunders", "jammer", longBio)
                     , ("2", "Donna Matrix", "blocker", longBio)
                     , ("3", "V-Diva", "jammer", longBio) ] )
        , ("bio", useAttrs (a"length" %
-                            a"text")
-                           shortenerFill))
+                           a"text")
+                           bioFill))
   where longBio = "Some example bio that is really long!"
-        shortenerFill maybeNumber fullBio = textFill $
+        bioFill maybeNumber fullBio = textFill $
           case maybeNumber of
             Just numChars -> T.take numChars fullBio <> "..."
             Nothing -> fullBio
@@ -87,8 +87,13 @@ understand and use (if slower).
 
 ## Differences from Heist
 
+The Haskell code you write to fill in your templates is very different
+from Heist, but we tried to make the templates themselves as similar
+as possible, with a couple notable exceptions:
+
 Larceny is different from Interpreted Heist (but similar to Compiled
-Heist) in that it doesn't escape any text.
+Heist) in that it doesn't escape any text. (This may change to make
+the default `textFill`s escaped and add `rawTextFill` versions.)
 
 In Heist, `<bind>`s inside of nested template application can be used
 in the outer templates. We found that confusing, so Larceny doesn't

--- a/larceny.cabal
+++ b/larceny.cabal
@@ -31,6 +31,7 @@ library
                      , directory >= 1.2.5
                      , filepath
                      , mtl
+                     , exceptions
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -53,6 +54,14 @@ test-suite test
   hs-source-dirs:      test
   default-language:    Haskell2010
 
+test-suite doctest
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Blah.hs
+  build-depends: base >= 4.8 && < 5
+               , larceny
+               , Glob >= 0.7
+               , doctest >= 0.9.12
 
 benchmark bench
   main-is:             Bench.hs

--- a/larceny.cabal
+++ b/larceny.cabal
@@ -54,15 +54,6 @@ test-suite test
   hs-source-dirs:      test
   default-language:    Haskell2010
 
-test-suite doctest
-  type: exitcode-stdio-1.0
-  hs-source-dirs: test
-  main-is: Blah.hs
-  build-depends: base >= 4.8 && < 5
-               , larceny
-               , Glob >= 0.7
-               , doctest >= 0.9.12
-
 benchmark bench
   main-is:             Bench.hs
   type:                exitcode-stdio-1.0

--- a/src/Web/Larceny.hs
+++ b/src/Web/Larceny.hs
@@ -355,7 +355,8 @@ useAttrs :: (Attributes -> k -> Fill s)
          ->  k
          ->  Fill s
 useAttrs k fill= Fill $ \atrs (pth, tpl) lib ->
-     unFill (k atrs fill) atrs (pth, tpl) lib
+  unFill (k atrs fill) atrs (pth, tpl) lib
+
 type AttrName = Text
 
 -- | If an attribute is required but missing, or unparsable, one of
@@ -432,11 +433,8 @@ mk o nodes =
     need pth m unbound <$>
     (T.concat <$> process (ProcessContext pth m l o unbound nodes))
 
-fillIn :: Text -> Substitutions s -> Path -> Fill s
-fillIn tn m pth =
-  fromMaybe
-     (textFill "")
-     (M.lookup (Blank tn) m)
+fillIn :: Text -> Substitutions s -> Fill s
+fillIn tn m = fromMaybe (textFill "") (M.lookup (Blank tn) m)
 
 data ProcessContext s = ProcessContext { _pcPath      :: Path
                                        , _pcSubs      :: Substitutions s

--- a/test/DocTest.hs
+++ b/test/DocTest.hs
@@ -1,0 +1,6 @@
+module Blah where
+
+import           DocTest
+import           System.FilePath.Glob (glob)
+
+main = glob "src/**/*.hs" >>= docTest


### PR DESCRIPTION
Oops, this also has a lot of documentation stuff.

This is making specific types for exceptions that could happen.

Is this the right way to do this? Should everything be one exception type, like `LarcenyException`, instead?