### PR TITLE
Allow attributes that aren't key-value pairs

### DIFF
--- a/src/Web/Larceny.hs
+++ b/src/Web/Larceny.hs
@@ -551,8 +551,7 @@ attrsToText :: ProcessContext s -> Map X.Name Text -> StateT s IO Text
 attrsToText pc attrs =
   T.concat <$> mapM attrToText (M.toList attrs)
   where attrToText (k,v) = do
-          let name = X.nameLocalName k
-              (unboundK, unboundV) =  eUnboundAttrs (k,v)
+          let (unboundK, unboundV) =  eUnboundAttrs (k,v)
           keys <- T.concat <$> mapM (fillAttr pc) unboundK
           vals <- T.concat <$> mapM (fillAttr pc) unboundV
           return $ toText (keys, vals)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -342,6 +342,19 @@ spec = hspec $ do
        mempty,
        mempty) `shouldRenderDef` "<br />"
 
+  describe "selected" $ do
+    it "should allow attributes that aren't k-v pairs" $ do
+      ("<option selected>Hello</option>",
+       mempty,
+       mempty) `shouldRenderDef` "<option selected>Hello</option>"
+
+    it "should allow blanks in attributes that aren't k-v pairs" $ do
+      ("<option ${selectedA}>Option A</option> \
+      \ <option ${selectedB}>Option B</option>",
+       subs [("selectedA", textFill ""), ("selectedB", textFill "selected")],
+       mempty) `shouldRenderDef`
+        "<option >Option A</option><option selected>Option B</option>"
+
 descFill :: Fill ()
 descFill =
   useAttrs (a"length" % a"ending") descFunc


### PR DESCRIPTION
For example, `<option selected>Option</option>`.

This was weird because html-conduit parses attributes into tuples of (name, value), even stuff like "selected". The attribute for `<option selected></option>` becomes [("selected", "")]. So what I'm doing below is looking for blanks in both the name and value and filling them all in. Then when it's time to render, checking if the value is blank to decide how to render.

I think it's an okay solution.