### PR TITLE
Allow base 4.9 (and thus ghc 8)

### DIFF
--- a/larceny.cabal
+++ b/larceny.cabal
@@ -42,7 +42,7 @@ test-suite test
   type:                exitcode-stdio-1.0
   other-modules:       Examples
   other-extensions:    OverloadedStrings
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.8 && <4.10
                      , containers >=0.5 && <0.6
                      , text >=1.2 && <1.3
                      , hspec >=2.2 && <2.3

--- a/larceny.cabal
+++ b/larceny.cabal
@@ -20,7 +20,7 @@ library
   exposed-modules:     Web.Larceny
                      , Web.Larceny.Html
   other-extensions:    OverloadedStrings
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.8 && <4.10
                      , containers >=0.5 && <0.6
                      , unordered-containers
                      , hashable


### PR DESCRIPTION
I've been using this locally, and it seems to work completely fine!