### PR TITLE
bump hspec to allow 2.4

### DIFF
--- a/larceny.cabal
+++ b/larceny.cabal
@@ -25,7 +25,7 @@ library
                      , unordered-containers
                      , hashable
                      , text >=1.2 && <1.3
-                     , hspec >=2.2 && <2.3
+                     , hspec >=2.2 && <2.5
                      , html-conduit
                      , xml-conduit
                      , directory >= 1.2.5
@@ -45,7 +45,7 @@ test-suite test
   build-depends:       base >=4.8 && <4.10
                      , containers >=0.5 && <0.6
                      , text >=1.2 && <1.3
-                     , hspec >=2.2 && <2.3
+                     , hspec >=2.2 && <2.5
                      , larceny
                      , unordered-containers
                      , directory >= 1.2.5
@@ -65,7 +65,7 @@ benchmark bench
   build-depends:       base >=4.8 && <4.9
                      , containers >=0.5 && <0.6
                      , text >=1.2 && <1.3
-                     , hspec >=2.2 && <2.3
+                     , hspec >=2.2 && <2.5
                      , xmlhtml
                      , larceny
                      , criterion


### PR DESCRIPTION
I haven't actually run the tests, but they still compile with hspec 2.4 -- and looking at the changelog, it doesn't seem like anything significant broke in 2.3 or 2.4. 